### PR TITLE
修复了前端4个问题

### DIFF
--- a/src/layouts/SecurityLayout.tsx
+++ b/src/layouts/SecurityLayout.tsx
@@ -48,7 +48,9 @@ const SecurityLayout = (props: SecurityLayoutProps) => {
       dispatch({
         type: 'settings/fetchConfig',
         callback: () => {
-          document.getElementById('title-icon')!.href = settings.titleIcon;
+          if (settings.titleIcon) {
+            document.getElementById('title-icon')!.href = settings.titleIcon;
+          }
           setIsReady(true);
         },
       });

--- a/src/pages/account/settings/security/index.tsx
+++ b/src/pages/account/settings/security/index.tsx
@@ -6,19 +6,21 @@ import Service from "../service";
 
 interface Props extends FormComponentProps { }
 const SecurityView: React.FC<Props> = (props) => {
-    const { form: { getFieldDecorator, getFieldsValue, getFieldValue, validateFields } } = props;
+    const { form: { getFieldDecorator, getFieldsValue, getFieldValue, validateFields, validateFieldsAndScroll } } = props;
 
     const service = new Service('user/passwd');
     const [confirmDirty, setConfirmDirty] = useState(false);
     const update = () => {
-        const data = getFieldsValue();
-        service.update(data).subscribe((resp) => {
-            if (resp) {
-                message.success('修改成功');
-            }
-        }, (error) => {
-            // message.error('修改失败!');
-        })
+        validateFieldsAndScroll((err, data) => {
+            if (err) return;
+            service.update(data).subscribe((resp) => {
+                if (resp) {
+                    message.success('修改成功');
+                }
+            }, (error) => {
+                // message.error('修改失败!');
+            })
+        });
     };
 
 

--- a/src/pages/system/permission/Save/association/index.tsx
+++ b/src/pages/system/permission/Save/association/index.tsx
@@ -135,7 +135,10 @@ const Association: React.FC<EditableTableProps> = (props) => {
         });
     }, []);
 
-    const cancel = () => {
+    const cancel = (key: any) => {
+        const newData = data.filter(item => item.key !== key);
+        setData(newData);
+        props.save(newData);
         setEditingKey('');
     };
 
@@ -216,7 +219,7 @@ const Association: React.FC<EditableTableProps> = (props) => {
                                 保存
                                 </a>
                         }
-                        <Popconfirm title="确认取消？" onConfirm={() => cancel()}>
+                        <Popconfirm title="确认取消？" onConfirm={() => cancel(record.key)}>
                             <a>取消</a>
                         </Popconfirm>
                     </span >

--- a/src/utils/request.ts
+++ b/src/utils/request.ts
@@ -112,8 +112,15 @@ const errorHandler = (error: { response: Response }): Response | undefined => {
       // router.push('/exception/403');
       // return;
     } else if (response.status === 404) {
+      if(window.location.hash.search("/user/login") != -1){
+        notification.error({
+          key: 'error',
+          message: '404 错误',
+        });
+        return response;
+      }
       // console.log(status, '状态');
-      router.push('/exception/404');
+        router.push('/exception/404');
     } else {
       notification.error({
         key: 'error',


### PR DESCRIPTION
修复了前端4个问题
1、个人设置-安全设置修改密码两次输入不一致虽然前端提示正确但后端数据仍可以被修改
2、修复登录页出现404时循环跳转异常页和登录页
3、修复登录后用户基本信息里头像不显示问题
4、关联权限添加权限删除界面问题
![image](https://user-images.githubusercontent.com/98011145/150094965-a3501157-8ac7-4be5-8470-6bd4cc7b91a5.png)

